### PR TITLE
Use Xlib to retrieve window dimensions

### DIFF
--- a/ueberzug/aio.py
+++ b/ueberzug/aio.py
@@ -11,7 +11,7 @@ class LineReader:
         """Waits asynchronously for a line and returns it"""
         return await loop.run_in_executor(None, file.readline)
 
-    async def __aiter__(self):
+    def __aiter__(self):
         return self
 
     async def __anext__(self):

--- a/ueberzug/terminal.py
+++ b/ueberzug/terminal.py
@@ -4,10 +4,11 @@ import fcntl
 import termios
 import math
 
+import Xlib.display
 
 class TerminalInfo:
     @staticmethod
-    def get_size(fd_pty=None):
+    def get_size(window_id, fd_pty=None):
         """Determines the columns, rows, width (px), height (px) of the terminal.
 
         Returns:
@@ -16,7 +17,15 @@ class TerminalInfo:
         fd_pty = fd_pty or sys.stdout.fileno()
         farg = struct.pack("HHHH", 0, 0, 0, 0)
         fretint = fcntl.ioctl(fd_pty, termios.TIOCGWINSZ, farg)
-        rows, cols, xpixels, ypixels = struct.unpack("HHHH", fretint)
+        rows, cols, _, _ = struct.unpack("HHHH", fretint)
+
+        display = Xlib.display.Display()
+        window = display.create_resource_object('window',window_id);
+
+        geometry = window.get_geometry();
+        xpixels = geometry.width;
+        ypixels = geometry.height;
+
         return cols, rows, xpixels, ypixels
 
     @staticmethod
@@ -33,22 +42,23 @@ class TerminalInfo:
         padding = (- font_size * chars + pixels) / 2
         return font_size, padding
 
-    def __init__(self, pty=None):
+    def __init__(self, window_id, pty=None):
         self.font_width = None
         self.font_height = None
         self.padding = None
+        self.window_id = window_id
 
         if isinstance(pty, (int, type(None))):
-            self.__calculate_sizes(pty)
+            self.__calculate_sizes(window_id,pty)
         else:
             with open(pty) as fd_pty:
-                self.__calculate_sizes(fd_pty)
+                self.__calculate_sizes(window_id,fd_pty)
 
-    def __calculate_sizes(self, fd_pty):
+    def __calculate_sizes(self, window_id, fd_pty):
         """Calculates the values for font_{width,height} and
         padding_{horizontal,vertical}.
         """
-        cols, rows, xpixels, ypixels = TerminalInfo.get_size(fd_pty)
+        cols, rows, xpixels, ypixels = TerminalInfo.get_size(window_id,fd_pty)
         self.font_width, padding_horizontal = \
             TerminalInfo.__get_font_size_padding(cols, xpixels)
         self.font_height, padding_vertical = \

--- a/ueberzug/xutil.py
+++ b/ueberzug/xutil.py
@@ -29,7 +29,7 @@ class Events:
         """Waits asynchronously for an x11 event and returns it"""
         return await loop.run_in_executor(None, display.next_event)
 
-    async def __aiter__(self):
+    def __aiter__(self):
         return self
 
     async def __anext__(self):
@@ -38,8 +38,8 @@ class Events:
 
 class TerminalWindowInfo(terminal.TerminalInfo):
     def __init__(self, window_id, fd_pty=None):
-        super().__init__(fd_pty)
         self.window_id = window_id
+        super().__init__(window_id,fd_pty)
 
 
 async def prepare_display():


### PR DESCRIPTION
Since it looks like some terminal emulators do not provide them via termios.TIOCGWINSZ.
Also fixes python 3.7 problem with some asyncs.