### PR TITLE
extend tmux event receivers (processes) instead of overwriting it

### DIFF
--- a/ueberzug/tmux_util.py
+++ b/ueberzug/tmux_util.py
@@ -12,10 +12,24 @@ def is_used():
 
 def get_pane():
     """Determines the pane identifier this process runs in.
+
     Returns:
         str or None
     """
     return os.environ.get('TMUX_PANE')
+
+
+def get_session_id():
+    """Determines the session identifier this process runs in.
+
+    Returns:
+        str
+    """
+    return subprocess.check_output([
+        'tmux', 'display', '-p',
+        '-F', '#{session_id}',
+        '-t', get_pane()
+    ]).decode().strip()
 
 
 def get_offset():


### PR DESCRIPTION
Instead of replacing the receiver pid of SIGUSR1 extend the kill command
with the new pids.
(Or remove a few depends on whether ueberzug starts or exits)

Resolves https://github.com/seebye/ueberzug/issues/14