### PR TITLE
Implemented 'MaxContainImageScaler'

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ ImageScalers:
 |---------------|----------------------------------------------------------------------------------|
 | crop          | Crops out an area of the size of the placement size.                             |
 | distort       | Distorts the image to the placement size.                                        |
-| contain       | Resizes the image to a size <= the placement size while keeping the image ratio. |
+| contain       | Resizes a larger image to a size <= the placement size while keeping the image ratio. |
+| max_contain   | Resizes the image to a size as large as possible within the placement size while keeping the image ratio. |
 | forced_cover  | Resizes the image to cover the entire area which should be filled<br>while keeping the image ratio.<br>If the image is smaller than the desired size<br>it will be stretched to reach the desired size.<br>If the ratio of the area differs<br>from the image ratio the edges will be cut off. |
 | cover         | The same as forced_cover but images won't be stretched<br>if they are smaller than the area which should be filled. |
 

--- a/ueberzug/scaling.py
+++ b/ueberzug/scaling.py
@@ -130,7 +130,7 @@ class DistortImageScaler(ImageScaler):
 
 class ContainImageScaler(DistortImageScaler):
     """Implementation of the ImageScaler
-    which resizes the image to a size <= the maximum size
+    which resizes a larger image to a size <= the maximum size
     while keeping the image ratio.
     """
 
@@ -150,7 +150,31 @@ class ContainImageScaler(DistortImageScaler):
 
         return int(image_width), int(image_height)
 
+    
+class MaxContainImageScaler(DistortImageScaler):
 
+    """Implementation of the ImageScaler
+    which resizes a smaller or larger image to the maximum size
+    within the bounds of the maximum width and height, while
+    keeping the image ratio.
+    """
+
+    @staticmethod
+    def get_scaler_name():
+        return "max_contain"
+    
+    def calculate_resolution(self, image, width: int, height: int):
+        image_width, image_height = image.width, image.height
+
+        if (width and image_width >= image_height):
+            image_height = image_height * width / image_width
+            image_width = width
+        elif (height and image_height >= image_width):
+            image_width = image_width * height / image_height
+            image_height = height
+
+        return int(image_width), int(image_height)
+    
 class ForcedCoverImageScaler(DistortImageScaler, OffsetImageScaler):
     """Implementation of the ImageScaler
     which resizes the image to cover the entire area which should be filled
@@ -201,6 +225,7 @@ class ScalerOption(str, enum.Enum):
     DISTORT = DistortImageScaler
     CROP = CropImageScaler
     CONTAIN = ContainImageScaler
+    MAX_CONTAIN = MaxContainImageScaler
     FORCED_COVER = ForcedCoverImageScaler
     COVER = CoverImageScaler
 


### PR DESCRIPTION
`MaxContainImageScaler` resizes a smaller or larger image to the maximum size possible within the target bounds while maintaining the aspect ratio.

Differs from `contain` which does not resize smaller images, and from `forced_cover` which crops images where the ratio does not match the ratio of the target bounds.