### PR TITLE
handle tmux client detachments

### DIFF
--- a/ueberzug/ueberzug.py
+++ b/ueberzug/ueberzug.py
@@ -135,7 +135,8 @@ def setup_tmux_hooks():
     events = (
         'client-session-changed',
         'session-window-changed',
-        'pane-mode-changed'
+        'pane-mode-changed',
+        'client-detached'
     )
     lock_directory_path = pathlib.PosixPath(tempfile.gettempdir()) / 'ueberzug'
     lock_file_path = lock_directory_path / tmux_util.get_session_id()


### PR DESCRIPTION
Well, somehow I overlooked the client-detached event.  
So.. just add a hook to get notified about client detachments & remove their overlay window if required.

Resolves https://github.com/seebye/ueberzug/issues/20