### PR TITLE
Extending fzf img to be useable without modifications

### DIFF
--- a/examples/fzfimg.sh
+++ b/examples/fzfimg.sh
@@ -89,7 +89,7 @@ function print_on_winch {
                 };
                 sleep;
             }' \
-            "$@"
+            "$@" &
 }
 
 
@@ -97,7 +97,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     trap finalise EXIT
     # print the redraw key twice as there's a run condition we can't circumvent
     # (we can't know the time fzf finished redrawing it's layout)
-    print_on_winch "${REDRAW_KEY}${REDRAW_KEY}" &
+    print_on_winch "${REDRAW_KEY}${REDRAW_KEY}"
     start_ueberzug
 
     export -f on_selection_changed calculate_position


### PR DESCRIPTION
Extending fzf img to be useable without modifications.  
E.g.:  

- always draw a static image::
```bash
fzfimg.sh --preview 'draw_preview /path/to/a/static/image'
```
- moving the preview to another place
```bash
fzfimg.sh --preview-window 'top:75%'
```