### PR TITLE
store big images in a lower resolution

### DIFF
--- a/ueberzug/layer.py
+++ b/ueberzug/layer.py
@@ -173,6 +173,8 @@ class View:
     def __init__(self):
         self.offset = geometry.Distance()
         self.media = {}
+        self.screen_width = 0
+        self.screen_height = 0
 
 
 class Tools:
@@ -185,6 +187,7 @@ class Tools:
 
 def main(options):
     display = xutil.get_display()
+    screen = display.screen()
     window_infos = xutil.get_parent_window_infos()
     loop = asyncio.get_event_loop()
     executor = thread.DaemonThreadPoolExecutor(max_workers=2)
@@ -198,6 +201,8 @@ def main(options):
     window_factory = ui.OverlayWindow.Factory(display, view)
     windows = batch.BatchList(window_factory.create(*window_infos))
     image_loader.register_error_handler(error_handler)
+    view.screen_width = screen.width_in_pixels
+    view.screen_height = screen.height_in_pixels
 
     if tmux_util.is_used():
         atexit.register(setup_tmux_hooks())

--- a/ueberzug/scaling.py
+++ b/ueberzug/scaling.py
@@ -17,7 +17,22 @@ class ImageScaler(metaclass=abc.ABCMeta):
     @staticmethod
     @abc.abstractmethod
     def get_scaler_name():
-        """Returns the constant name which is associated to this scaler."""
+        """Returns:
+            str: the constant name which is associated to this scaler.
+        """
+        raise NotImplementedError()
+
+    @staticmethod
+    @abc.abstractmethod
+    def is_indulgent_resizing():
+        """This method specifies whether the
+        algorithm returns noticeable different results for
+        the same image with different sizes (bigger than the
+        maximum size which is passed to the scale method).
+
+        Returns:
+            bool: False if the results differ
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -98,6 +113,10 @@ class CropImageScaler(MinSizeImageScaler, OffsetImageScaler):
     def get_scaler_name():
         return "crop"
 
+    @staticmethod
+    def is_indulgent_resizing():
+        return False
+
     def scale(self, image, position: geometry.Point,
               width: int, height: int):
         width, height = self.calculate_resolution(image, width, height)
@@ -117,6 +136,10 @@ class DistortImageScaler(ImageScaler):
     @staticmethod
     def get_scaler_name():
         return "distort"
+
+    @staticmethod
+    def is_indulgent_resizing():
+        return True
 
     def calculate_resolution(self, image, width: int, height: int):
         return width, height
@@ -140,6 +163,10 @@ class FitContainImageScaler(DistortImageScaler):
     def get_scaler_name():
         return "fit_contain"
 
+    @staticmethod
+    def is_indulgent_resizing():
+        return True
+
     def calculate_resolution(self, image, width: int, height: int):
         factor = min(width / image.width, height / image.height)
         return int(image.width * factor), int(image.height * factor)
@@ -154,6 +181,10 @@ class ContainImageScaler(FitContainImageScaler):
     @staticmethod
     def get_scaler_name():
         return "contain"
+
+    @staticmethod
+    def is_indulgent_resizing():
+        return True
 
     def calculate_resolution(self, image, width: int, height: int):
         return super().calculate_resolution(
@@ -173,6 +204,10 @@ class ForcedCoverImageScaler(DistortImageScaler, OffsetImageScaler):
     @staticmethod
     def get_scaler_name():
         return "forced_cover"
+
+    @staticmethod
+    def is_indulgent_resizing():
+        return True
 
     def scale(self, image, position: geometry.Point,
               width: int, height: int):
@@ -202,6 +237,10 @@ class CoverImageScaler(MinSizeImageScaler, ForcedCoverImageScaler):
     @staticmethod
     def get_scaler_name():
         return "cover"
+
+    @staticmethod
+    def is_indulgent_resizing():
+        return True
 
 
 @enum.unique


### PR DESCRIPTION
resolves https://github.com/seebye/ueberzug/issues/81

There are common sizes in which images are
likely to be displayed in.
(smaller or equal to the screen size)
If images reach a specific resolution the
principle of spatial locality doesn't apply anymore
to resize operations to common sizes
(e.g. 6000x6000 to 300x300).
So to reduce cache misses and therefore avoid
a worse performance images are stored by default up to a size
which is about the same as the screen size.
Images will be fully loaded if it's required by their
image scaler or if they should be displayed with a size
which is bigger than the screen size.