### PR TITLE
loading images: convert L,P mode PNGs to RGBA PNGs

### DIFF
--- a/ueberzug/loading.py
+++ b/ueberzug/loading.py
@@ -43,6 +43,14 @@ def load_image(path, upper_bound_size):
 
     image.load()
 
+    if (image.format == 'PNG'
+            and image.mode in ('L', 'P')
+            and 'transparency' in image.info):
+        # Prevent pillow to print the warning
+        # 'Palette images with Transparency expressed in bytes should be
+        #  converted to RGBA images'
+        image = image.convert('RGBA')
+
     if image.mode == 'RGBA':
         mask = image.split()[INDEX_ALPHA_CHANNEL]
 


### PR DESCRIPTION
L,P PNGs with transparency will be converted to RGBA PNGs
to surpress the following warning (pillow):
Palette images with Transparency expressed in bytes should be
converted to RGBA images