### PR TITLE
fix python39 lack of backwards compatibility

### DIFF
--- a/ueberzug/layer.py
+++ b/ueberzug/layer.py
@@ -86,8 +86,15 @@ async def reset_terminal_info(windows):
 
 
 async def shutdown(loop):
-    tasks = [task for task in asyncio.Task.all_tasks()
-             if task is not asyncio.tasks.Task.current_task()]
+    try:
+        all_tasks = asyncio.all_tasks()
+        current_task = asyncio.current_task()
+    except AttributeError:
+        all_tasks = asyncio.Task.all_tasks()
+        current_task = asyncio.tasks.Task.current_task()
+
+    tasks = [task for task in all_tasks
+             if task is not current_task]
     list(map(lambda task: task.cancel(), tasks))
     await asyncio.gather(*tasks, return_exceptions=True)
     loop.stop()


### PR DESCRIPTION
In python3.9 asyncio.Task.all_task() and asyncio.Task.current_task() were removed.
See: https://docs.python.org/3/whatsnew/3.9.html#removed
They advise to use asyncio.all_task() and asyncio.current_task()
instead.
At the time of this commit python3.6 is still used by 10% of the users
(counted by the reported python version of the downloads).
So we need to reduce the readability by adding redundant try except
blocks.

resolves https://github.com/seebye/ueberzug/issues/127