### PR TITLE
Add --window-id as an optional argunment

### DIFF
--- a/ueberzug/__main__.py
+++ b/ueberzug/__main__.py
@@ -23,6 +23,8 @@ Layer options:
                            thread: load images in threads
                            process: load images in additional processes
                            [default: thread]
+    --window-id <id>       set the window id that the layer will displays on,
+                           to disambiguate pid that contains multiple windows
     -s, --silent           print stderr to /dev/null
 
 

--- a/ueberzug/layer.py
+++ b/ueberzug/layer.py
@@ -200,10 +200,15 @@ def main(options):
             os.dup2(outfile, sys.stderr.fileno())
         finally:
             os.close(outfile)
+    if options['--window-id']:
+        try:
+            options['--window-id'] = int(options['--window-id'])
+        except ValueError:
+            raise ValueError("Optional argunment --window-id should be an integer, but was '%s'." % options['--window-id'])
 
     display = xutil.get_display()
     screen = display.screen()
-    window_infos = xutil.get_parent_window_infos()
+    window_infos = xutil.get_parent_window_infos(options['--window-id'])
     loop = asyncio.get_event_loop()
     executor = thread.DaemonThreadPoolExecutor(max_workers=2)
     parser_object = (parser.ParserOption(options['--parser'])


### PR DESCRIPTION
This enables user to pass in an optional argunment `--window-id` to disambiguate processes that contains multiple window.    
    
## Why    
    
This makes it so that `ueberzug` works for process that contains multiple windows (e.g. terminal emulator that uses daemon) by specifing window id obtained via something like:    
    
```sh    
xdotool getactivewindow    
# or xdotool getwindowfocus    
```    
    
e.g.    
```sh    
echo '{"action": "add", "identifier": "test", "x": 0, "y": 0, "path": "/photo.jpg"}' | ueberzug layer --window-id "$(xdotool getactivewindow)"    
```    
    
For almost all useful usecases `ueberzug` is called by the active process (e.g. ranger in terminal) that is currently in active or focused. It is also trivial to performs sanity checks with the given `--window-id` against the current pid.