### PR TITLE
Fix multiple definitions

### DIFF
--- a/ueberzug/X/X.c
+++ b/ueberzug/X/X.c
@@ -4,7 +4,7 @@
 #include "Xshm.h"
 
 
-static PyModuleDef module = {
+PyModuleDef module = {
     PyModuleDef_HEAD_INIT,
     .m_name = "ueberzug.X",
     .m_doc = "Modul which implements the interaction with the Xshm extension.",

--- a/ueberzug/X/X.h
+++ b/ueberzug/X/X.h
@@ -3,5 +3,5 @@
 #include "python.h"
 
 
-PyModuleDef module;
+extern PyModuleDef module;
 #endif

--- a/ueberzug/X/Xshm.h
+++ b/ueberzug/X/Xshm.h
@@ -3,5 +3,5 @@
 #include "python.h"
 
 
-PyTypeObject ImageType;
+extern PyTypeObject ImageType;
 #endif

--- a/ueberzug/X/display.h
+++ b/ueberzug/X/display.h
@@ -24,6 +24,7 @@ typedef struct {
     Atom wm_locale_name;
     Atom wm_normal_hints;
 } DisplayObject;
-PyTypeObject DisplayType;
+
+extern PyTypeObject DisplayType;
 
 #endif

--- a/ueberzug/X/window.h
+++ b/ueberzug/X/window.h
@@ -3,5 +3,5 @@
 #include "python.h"
 
 
-PyTypeObject WindowType;
+extern PyTypeObject WindowType;
 #endif


### PR DESCRIPTION
Even though You don't accept PRs just letting You know that this package doesn't compile for i.e. Arch Linux without this fix because of multiple definitions of the same object. So I would suggest either merge this PR or make another fix.

Below are failing logs for building package:

> $ python3 setup.py build
running build
running build_py
running egg_info
writing ueberzug.egg-info/PKG-INFO
writing dependency_links to ueberzug.egg-info/dependency_links.txt
writing entry points to ueberzug.egg-info/entry_points.txt
writing requirements to ueberzug.egg-info/requires.txt
writing top-level names to ueberzug.egg-info/top_level.txt
adding license file 'LICENSE' (matched pattern 'LICEN[CS]E*')
reading manifest file 'ueberzug.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'ueberzug.egg-info/SOURCES.txt'
copying ueberzug/X/X.c -> build/lib.linux-x86_64-3.9/ueberzug/X
copying ueberzug/X/X.h -> build/lib.linux-x86_64-3.9/ueberzug/X
copying ueberzug/X/Xshm.h -> build/lib.linux-x86_64-3.9/ueberzug/X
copying ueberzug/X/display.h -> build/lib.linux-x86_64-3.9/ueberzug/X
copying ueberzug/X/window.h -> build/lib.linux-x86_64-3.9/ueberzug/X
running build_ext
building 'ueberzug.X' extension
gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fno-semantic-interposition -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fPIC -Iueberzug/X -I/home/dominik/repos/ueberzug/venv/include -I/usr/include/python3.9 -c ueberzug/X/X.c -o build/temp.linux-x86_64-3.9/ueberzug/X/X.o
gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fno-semantic-interposition -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fPIC -Iueberzug/X -I/home/dominik/repos/ueberzug/venv/include -I/usr/include/python3.9 -c ueberzug/X/Xshm.c -o build/temp.linux-x86_64-3.9/ueberzug/X/Xshm.o
gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fno-semantic-interposition -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fPIC -Iueberzug/X -I/home/dominik/repos/ueberzug/venv/include -I/usr/include/python3.9 -c ueberzug/X/display.c -o build/temp.linux-x86_64-3.9/ueberzug/X/display.o
gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fno-semantic-interposition -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fPIC -Iueberzug/X -I/home/dominik/repos/ueberzug/venv/include -I/usr/include/python3.9 -c ueberzug/X/window.c -o build/temp.linux-x86_64-3.9/ueberzug/X/window.o
gcc -pthread -shared -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now -fno-semantic-interposition -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now build/temp.linux-x86_64-3.9/ueberzug/X/X.o build/temp.linux-x86_64-3.9/ueberzug/X/Xshm.o build/temp.linux-x86_64-3.9/ueberzug/X/display.o build/temp.linux-x86_64-3.9/ueberzug/X/window.o -L/usr/lib -lX11 -lXext -lXRes -o build/lib.linux-x86_64-3.9/ueberzug/X.cpython-39-x86_64-linux-gnu.so
/usr/bin/ld: build/temp.linux-x86_64-3.9/ueberzug/X/Xshm.o:/home/dominik/repos/ueberzug/ueberzug/X/display.h:27: multiple definition of `DisplayType'; build/temp.linux-x86_64-3.9/ueberzug/X/X.o:/home/dominik/repos/ueberzug/ueberzug/X/display.h:27: first defined here
/usr/bin/ld: build/temp.linux-x86_64-3.9/ueberzug/X/Xshm.o:/home/dominik/repos/ueberzug/ueberzug/X/Xshm.c:279: multiple definition of `ImageType'; build/temp.linux-x86_64-3.9/ueberzug/X/X.o:/home/dominik/repos/ueberzug/ueberzug/X/Xshm.h:6: first defined here
/usr/bin/ld: build/temp.linux-x86_64-3.9/ueberzug/X/display.o:/home/dominik/repos/ueberzug/ueberzug/X/display.h:27: multiple definition of `DisplayType'; build/temp.linux-x86_64-3.9/ueberzug/X/X.o:/home/dominik/repos/ueberzug/ueberzug/X/display.h:27: first defined here
/usr/bin/ld: build/temp.linux-x86_64-3.9/ueberzug/X/window.o:/home/dominik/repos/ueberzug/ueberzug/X/display.h:27: multiple definition of `DisplayType'; build/temp.linux-x86_64-3.9/ueberzug/X/X.o:/home/dominik/repos/ueberzug/ueberzug/X/display.h:27: first defined here
/usr/bin/ld: build/temp.linux-x86_64-3.9/ueberzug/X/window.o:/home/dominik/repos/ueberzug/ueberzug/X/window.c:299: multiple definition of `WindowType'; build/temp.linux-x86_64-3.9/ueberzug/X/X.o:/home/dominik/repos/ueberzug/ueberzug/X/window.h:6: first defined here
collect2: error: ld returned 1 exit status
error: command '/usr/bin/gcc' failed with exit code 1
 