### PR TITLE
use per user lock file

### DIFF
--- a/ueberzug/layer.py
+++ b/ueberzug/layer.py
@@ -122,7 +122,8 @@ def setup_tmux_hooks():
         'pane-mode-changed',
         'client-detached'
     )
-    lock_directory_path = pathlib.PosixPath(tempfile.gettempdir()) / 'ueberzug'
+    lock_directory_path = pathlib.PosixPath.joinpath(pathlib.PosixPath.home(),
+            pathlib.PosixPath('.cache/ueberzug'))
     lock_file_path = lock_directory_path / tmux_util.get_session_id()
     own_pid = str(os.getpid())
     command_template = 'ueberzug query_windows '


### PR DESCRIPTION
using /tmp/ueberzug/ as `lock_directory_path` causes ueberzug to not display images on multi user systems as users that use ueberzug after the first user who created the lock file won't have the permissions to overwrite said lock file.